### PR TITLE
Add theme field with filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vocabulary_app
 
-A simple web application for managing Japanese vocabulary. You can add, edit and delete words and store them locally in your browser. The vocabulary can also be exported to a JSON file or loaded from a file.
+A simple web application for managing Japanese vocabulary. You can add, edit and delete words and store them locally in your browser. The vocabulary can also be exported to a JSON file or loaded from a file. Each entry can be tagged with a **theme** which allows the list to be filtered.
 
 This app runs entirely in your browser and does not require Node.js or any server.
 
@@ -8,9 +8,11 @@ This app runs entirely in your browser and does not require Node.js or any serve
 
 1. Open `index.html` in a web browser.
 2. Fill in the form with the word's details (hiragana and English are required).
-3. Click **Add Word** to save the entry.
-4. Use **Edit** or **Delete** in the table to modify your list.
-5. Use **Save to File** to download your vocabulary as `vocabulary.json`.
-6. Use **Load from File** to import a previously saved file.
+3. Optionally provide a **theme** for the entry to categorise it.
+4. Click **Add Word** to save the entry.
+5. Use the **Filter by Theme** dropdown above the table to show only words from a specific theme.
+6. Use **Edit** or **Delete** in the table to modify your list.
+7. Use **Save to File** to download your vocabulary as `vocabulary.json`.
+8. Use **Load from File** to import a previously saved file.
 
 All data is also stored in the browser's `localStorage` so your vocabulary stays when you reload the page.

--- a/index.html
+++ b/index.html
@@ -20,9 +20,16 @@
         <label>Hiragana*: <input type="text" id="hiragana" required></label>
         <label>Katakana: <input type="text" id="katakana"></label>
         <label>English*: <input type="text" id="english" required></label>
+        <label>Theme: <input type="text" id="theme"></label>
         <button type="submit" id="save-btn">Add Word</button>
         <button type="button" id="cancel-edit" style="display:none;">Cancel</button>
     </form>
+
+    <label>Filter by Theme:
+        <select id="theme-filter">
+            <option value="all">All</option>
+        </select>
+    </label>
 
     <h2>Vocabulary List</h2>
     <table id="vocab-table">
@@ -32,6 +39,7 @@
                 <th>Hiragana</th>
                 <th>Katakana</th>
                 <th>English</th>
+                <th>Theme</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -51,6 +59,8 @@
     const hiraganaInput = document.getElementById('hiragana');
     const katakanaInput = document.getElementById('katakana');
     const englishInput = document.getElementById('english');
+    const themeInput = document.getElementById('theme');
+    const themeFilter = document.getElementById('theme-filter');
     const saveBtn = document.getElementById('save-btn');
     const cancelEditBtn = document.getElementById('cancel-edit');
     const tableBody = document.querySelector('#vocab-table tbody');
@@ -72,19 +82,41 @@
 
     function renderTable() {
         tableBody.innerHTML = '';
-        vocabList.forEach((item, index) => {
+        const filter = themeFilter.value;
+        const list = filter === 'all' ? vocabList : vocabList.filter(i => i.theme === filter);
+        list.forEach((item) => {
+            const index = vocabList.indexOf(item);
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td>${item.kanji || ''}</td>
                 <td>${item.hiragana}</td>
                 <td>${item.katakana || ''}</td>
                 <td>${item.english}</td>
+                <td>${item.theme || ''}</td>
                 <td class="actions">
                     <button data-index="${index}" class="edit-btn">Edit</button>
                     <button data-index="${index}" class="delete-btn">Delete</button>
                 </td>`;
             tableBody.appendChild(row);
         });
+        updateFilterOptions();
+    }
+
+    function updateFilterOptions() {
+        const themes = [...new Set(vocabList.map(v => v.theme).filter(t => t))];
+        const current = themeFilter.value;
+        themeFilter.innerHTML = '<option value="all">All</option>';
+        themes.forEach(t => {
+            const opt = document.createElement('option');
+            opt.value = t;
+            opt.textContent = t;
+            themeFilter.appendChild(opt);
+        });
+        if (current && themes.includes(current)) {
+            themeFilter.value = current;
+        } else {
+            themeFilter.value = 'all';
+        }
     }
 
     function resetForm() {
@@ -100,7 +132,8 @@
             kanji: kanjiInput.value.trim(),
             hiragana: hiraganaInput.value.trim(),
             katakana: katakanaInput.value.trim(),
-            english: englishInput.value.trim()
+            english: englishInput.value.trim(),
+            theme: themeInput.value.trim()
         };
         if (!entry.hiragana || !entry.english) {
             alert('Hiragana and English are required');
@@ -134,6 +167,7 @@
             hiraganaInput.value = item.hiragana;
             katakanaInput.value = item.katakana || '';
             englishInput.value = item.english;
+            themeInput.value = item.theme || '';
             editIndex = index;
             saveBtn.textContent = 'Save';
             cancelEditBtn.style.display = 'inline';
@@ -176,6 +210,10 @@
         };
         reader.readAsText(file);
         importFileInput.value = '';
+    });
+
+    themeFilter.addEventListener('change', () => {
+        renderTable();
     });
 
     loadFromLocal();


### PR DESCRIPTION
## Summary
- add `theme` field to vocabulary form
- show theme column in the table
- allow filtering vocabulary entries by theme
- document theme usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852408f858883338d7ee950155dae2c