### PR TITLE
Enable theme selection in practice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ This app runs entirely in your browser and does not require Node.js or any serve
 7. Use **Save to File** to download your vocabulary as `vocabulary.json`.
 8. Use **Load from File** to import a previously saved file.
 
+9. Open `practice.html` to play a quiz game. Select one or more themes before starting.
 All data is also stored in the browser's `localStorage` so your vocabulary stays when you reload the page.

--- a/practice.html
+++ b/practice.html
@@ -41,6 +41,12 @@
                 </select>
             </label>
         </div>
+        <div>
+            <label>
+                Themes:
+                <select id="theme-select" multiple size="5"></select>
+            </label>
+        </div>
         <p>Best Score: <span id="best-score">0</span></p>
         <button id="start-btn">Start Game</button>
     </div>
@@ -81,6 +87,7 @@
     const finalScoreEl = document.getElementById('final-score');
     const restartBtn = document.getElementById('restart-btn');
 
+    const themeSelect = document.getElementById("theme-select");
     let vocabList = [];
     let shuffled = [];
     let index = 0;
@@ -101,6 +108,17 @@
             }
         }
     }
+    function updateThemeOptions() {
+        const themes = [...new Set(vocabList.map(v => v.theme).filter(t => t))];
+        themeSelect.innerHTML = "";
+        themes.forEach(t => {
+            const opt = document.createElement("option");
+            opt.value = t;
+            opt.textContent = t;
+            themeSelect.appendChild(opt);
+        });
+    }
+
 
     function shuffle(array) {
         for (let i = array.length - 1; i > 0; i--) {
@@ -112,6 +130,7 @@
 
     function startGame() {
         loadVocab();
+        updateThemeOptions();
         const mode = modeSelect.value;
         const conv = conversionSelect.value;
         const diff = difficultySelect.value;
@@ -128,14 +147,19 @@
         gameOverDiv.classList.add('hidden');
         timerEl.classList.toggle('hidden', !hardMode);
         if (hardMode) timeLeftEl.textContent = 15;
+        const selectedThemes = Array.from(themeSelect.selectedOptions).map(o => o.value);
+        if (selectedThemes.length === 0) {
+            alert("Please select at least one theme.");
+            return;
+        }
 
-        shuffled = vocabList.filter(v => {
-            if (mode === 'jp-en') {
-                if (conv === 'kana') return v.hiragana || v.katakana;
-                if (conv === 'kanji') return v.kanji;
+        shuffled = vocabList.filter(v => selectedThemes.includes(v.theme)).filter(v => {
+            if (mode === "jp-en") {
+                if (conv === "kana") return v.hiragana || v.katakana;
+                if (conv === "kanji") return v.kanji;
             } else {
-                if (conv === 'kana') return v.hiragana || v.katakana;
-                if (conv === 'kanji') return v.kanji;
+                if (conv === "kana") return v.hiragana || v.katakana;
+                if (conv === "kanji") return v.kanji;
             }
             return false;
         });
@@ -264,6 +288,8 @@
         gameDiv.style.display = 'none';
     });
 
+    loadVocab();
+    updateThemeOptions();
     bestScore = parseInt(localStorage.getItem('bestScore') || '0', 10);
     bestScoreEl.textContent = bestScore;
     </script>


### PR DESCRIPTION
## Summary
- let players choose themes before starting practice
- show available themes in a multi-select list
- filter practice questions by the chosen themes
- document practice page usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fb041cf84833391313b90e742f08a