### PR TITLE
Improve theme selection UI on practice page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ This app runs entirely in your browser and does not require Node.js or any serve
 7. Use **Save to File** to download your vocabulary as `vocabulary.json`.
 8. Use **Load from File** to import a previously saved file.
 
-9. Open `practice.html` to play a quiz game. Select one or more themes before starting.
+9. Open `practice.html` to play a quiz game. Use the theme checkboxes to choose which themes to practice with before starting.
 All data is also stored in the browser's `localStorage` so your vocabulary stays when you reload the page.

--- a/practice.html
+++ b/practice.html
@@ -47,9 +47,8 @@
             </div>
         </div>
         <div class="mb-2">
-            <label class="form-label">Themes
-                <select id="theme-select" class="form-select" multiple size="5"></select>
-            </label>
+            <label class="form-label d-block">Themes</label>
+            <div id="theme-checks" class="form-control" style="max-height:10rem;overflow-y:auto;"></div>
         </div>
         <p class="mb-1">Best Score: <span id="best-score">0</span></p>
         <button id="start-btn" class="btn btn-primary">Start Game</button>
@@ -93,7 +92,7 @@
     const finalScoreEl = document.getElementById('final-score');
     const restartBtn = document.getElementById('restart-btn');
 
-    const themeSelect = document.getElementById("theme-select");
+    const themeChecks = document.getElementById('theme-checks');
     let vocabList = [];
     let shuffled = [];
     let index = 0;
@@ -116,12 +115,22 @@
     }
     function updateThemeOptions() {
         const themes = [...new Set(vocabList.map(v => v.theme).filter(t => t))];
-        themeSelect.innerHTML = "";
+        themeChecks.innerHTML = '';
         themes.forEach(t => {
-            const opt = document.createElement("option");
-            opt.value = t;
-            opt.textContent = t;
-            themeSelect.appendChild(opt);
+            const div = document.createElement('div');
+            div.className = 'form-check';
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.className = 'form-check-input';
+            input.id = `theme-${t}`;
+            input.value = t;
+            const label = document.createElement('label');
+            label.className = 'form-check-label';
+            label.htmlFor = `theme-${t}`;
+            label.textContent = t;
+            div.appendChild(input);
+            div.appendChild(label);
+            themeChecks.appendChild(div);
         });
     }
 
@@ -153,7 +162,7 @@
         gameOverDiv.classList.add('hidden');
         timerEl.classList.toggle('hidden', !hardMode);
         if (hardMode) timeLeftEl.textContent = 15;
-        const selectedThemes = Array.from(themeSelect.selectedOptions).map(o => o.value);
+        const selectedThemes = Array.from(themeChecks.querySelectorAll('input:checked')).map(cb => cb.value);
         if (selectedThemes.length === 0) {
             alert("Please select at least one theme.");
             return;


### PR DESCRIPTION
## Summary
- switch theme selector from multi-select dropdown to scrollable checkboxes
- update JS logic for new checkbox-based selection
- document the new checkbox UI in README

## Testing
- `html5validator --version` *(fails: command not found)*
- `tidy -errors practice.html` *(fails: command not found)*
- `python3 - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'lxml')*

------
https://chatgpt.com/codex/tasks/task_e_685ff6700c9c8333b84be13f53d5ccdc