### PR TITLE
Fix theme selection in practice mode

### DIFF
--- a/practice.html
+++ b/practice.html
@@ -145,7 +145,6 @@
 
     function startGame() {
         loadVocab();
-        updateThemeOptions();
         const mode = modeSelect.value;
         const conv = conversionSelect.value;
         const diff = difficultySelect.value;


### PR DESCRIPTION
## Summary
- keep user selected themes when starting practice mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68615129d0c48333bc26433f19a4908a